### PR TITLE
Implement the rand.Source interface for the accuumulator

### DIFF
--- a/accumulator.go
+++ b/accumulator.go
@@ -269,7 +269,5 @@ func (acc *Accumulator) Int63() int64 {
 // Use of this method should be avoided in cryptographic applications,
 // since reproducible output will lead to security vulnerabilities.
 func (acc *Accumulator) Seed(seed int64) {
-	acc.genMutex.Lock()
-	defer acc.genMutex.Unlock()
-	acc.gen.Seed(seed)
+	panic("Seeding is not supported")
 }

--- a/accumulator_test.go
+++ b/accumulator_test.go
@@ -172,3 +172,21 @@ func cryptoRandRead(b *testing.B, n int) {
 func BenchmarkCryptoRandRead16(b *testing.B) { cryptoRandRead(b, 16) }
 func BenchmarkCryptoRandRead32(b *testing.B) { cryptoRandRead(b, 32) }
 func BenchmarkCryptoRandRead1k(b *testing.B) { cryptoRandRead(b, 1024) }
+
+func TestRandInt63(t *testing.T) {
+	acc, _ := NewRNG("")
+	r := acc.Int63()
+	if r < 0 {
+		t.Error("Invalid random output")
+	}
+}
+
+func TestRandSeed(t *testing.T) {
+	acc, _ := NewRNG("")
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("Failed to panic")
+		}
+	}()
+	acc.Seed(0)
+}


### PR DESCRIPTION
When using the RNG in a web app (i.e. with multiple goroutines), it's pretty handy to be able to use the accumulator as a (thread-safe) random source.
